### PR TITLE
Weapon categories & ui changes

### DIFF
--- a/items/active/weapons/aeolus_weapons/aeolus_shortbow_1/aeolus_shortbow_1.activeitem
+++ b/items/active/weapons/aeolus_weapons/aeolus_shortbow_1/aeolus_shortbow_1.activeitem
@@ -7,7 +7,8 @@
   "description" : "A shortbow that fires light arrows at an extremely fast speed.",
   "shortdescription" : "Ariostone Shortbow",
   "tooltipKind" : "base",
-  "category" : "arcana_shortbow",
+  "category" : "bow",
+  "tooltipFields" : {"subtitle" : "Shortbow"},
   "twoHanded" : true,
   "itemTags" : ["weapon","ranged"],
   "collectablesOnPickup" : { "arcana_collection_weapon_elemental" : "aeolus_shortbow_1" },
@@ -77,5 +78,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/aeolus_weapons/aeolus_shortbow_2/aeolus_shortbow_2.activeitem
+++ b/items/active/weapons/aeolus_weapons/aeolus_shortbow_2/aeolus_shortbow_2.activeitem
@@ -7,7 +7,8 @@
   "description" : "A shortbow that fires light arrows at an extremely fast speed.",
   "shortdescription" : "Zephyr",
   "tooltipKind" : "base",
-  "category" : "arcana_shortbow",
+  "category" : "bow",
+  "tooltipFields" : {"subtitle" : "Shortbow"},
   "twoHanded" : true,
   "itemTags" : ["weapon","ranged"],
 
@@ -83,5 +84,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/aeon_weapons/aeon_battleaxe_1/aeon_battleaxe_1.activeitem
+++ b/items/active/weapons/aeon_weapons/aeon_battleaxe_1/aeon_battleaxe_1.activeitem
@@ -7,9 +7,10 @@
   "description" : "A battleaxe created with the timeless aeons.",
   "shortdescription" : "Sagacity",
   "tooltipKind" : "sword",
-  "category" : "arcana_battleaxe",
+  "category" : "axe",
+  "tooltipFields" : {"subtitle" : "Battleaxe"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee","broadsword"],
+  "itemTags" : ["weapon","melee","battleaxe","axe"],
 
   "inventoryIcon" : "aeon_battleaxe_1.png",
 
@@ -38,5 +39,5 @@
 
   "altAbilityType" : "kunaiblast",
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/aeon_weapons/aeon_lance_1/aeon_lance_1.activeitem
+++ b/items/active/weapons/aeon_weapons/aeon_lance_1/aeon_lance_1.activeitem
@@ -7,7 +7,8 @@
   "description" : "A yellowish lance.",
   "shortdescription" : "Acuity",
   "tooltipKind" : "sword",
-  "category" : "arcana_lance",
+  "category" : "spear",
+  "tooltipFields" : {"subtitle" : "Lance"},
   "twoHanded" : true,
   "itemTags" : ["weapon","melee","spear"],
 
@@ -47,5 +48,5 @@
     "cooldownTime" : 0.3
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/aeon_weapons/aeon_shortbow_1/aeon_shortbow_1.activeitem
+++ b/items/active/weapons/aeon_weapons/aeon_shortbow_1/aeon_shortbow_1.activeitem
@@ -7,9 +7,10 @@
   "description" : "A golden shortbow, can instantly fire arrows.",
   "shortdescription" : "Aeon Shortbow",
   "tooltipKind" : "base",
-  "category" : "arcana_shortbow",
+  "category" : "bow",
+  "tooltipFields" : {"subtitle" : "Shortbow"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","ranged"],
+  "itemTags" : ["weapon","ranged","bow","shortbow"],
 
   "inventoryIcon" : "icon.png",
 
@@ -76,5 +77,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/artifact_weapons/artifact_doubleBlade_eternity/artifact_doubleBlade_eternity.activeitem
+++ b/items/active/weapons/artifact_weapons/artifact_doubleBlade_eternity/artifact_doubleBlade_eternity.activeitem
@@ -7,9 +7,10 @@
   "description" : "The eternal thunder that brings down divine judgement.",
   "shortdescription" : "Eternity",
   "tooltipKind" : "sword",
-  "category" : "arcana_doubleBlade",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Double Blade"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee"],
+  "itemTags" : ["weapon","melee","doubleblade"],
 
   "inventoryIcon" : "icon.png",
 
@@ -38,5 +39,5 @@
   
   "altAbilityType" : "traildash",
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/artifact_weapons/artifact_katana_judgement/artifact_katana_judgement.activeitem
+++ b/items/active/weapons/artifact_weapons/artifact_katana_judgement/artifact_katana_judgement.activeitem
@@ -7,9 +7,10 @@
   "description" : "The absolution brought by a piece of the brighter horizon.",
   "shortdescription" : "Judgement",
   "tooltipKind" : "sword",
-  "category" : "arcana_katana",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Katana"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee"],
+  "itemTags" : ["weapon","melee","katana"],
 
   "inventoryIcon" : "icon.png",
 
@@ -52,5 +53,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/artifact_weapons/artifact_lance_astrifer/artifact_lance_astrifer.activeitem
+++ b/items/active/weapons/artifact_weapons/artifact_lance_astrifer/artifact_lance_astrifer.activeitem
@@ -7,7 +7,8 @@
   "description" : "A lance comparable to the brightest azure star.",
   "shortdescription" : "Astrifer",
   "tooltipKind" : "sword",
-  "category" : "arcana_lance",
+  "category" : "spear",
+  "tooltipFields" : {"subtitle" : "Lance"},
   "twoHanded" : true,
   "itemTags" : ["weapon","melee","spear"],
 
@@ -60,5 +61,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/artifact_weapons/artifact_orb_grandCross/artifact_orb_grandCross.activeitem
+++ b/items/active/weapons/artifact_weapons/artifact_orb_grandCross/artifact_orb_grandCross.activeitem
@@ -6,7 +6,8 @@
   "rarity" : "Essential",
   "description" : "A strange device embed with a cross.",
   "shortdescription" : "Grand Cross",
-  "category" : "arcana_orb",
+  "category" : "wand",
+  "tooltipFields" : {"subtitle" : "Orb"},
   "twoHanded" : false,
   "itemTags" : ["weapon","staff"],
   "tooltipKind" : "staff",
@@ -118,5 +119,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/artifact_weapons/artifact_orb_nil/artifact_orb_nil.activeitem
+++ b/items/active/weapons/artifact_weapons/artifact_orb_nil/artifact_orb_nil.activeitem
@@ -6,7 +6,8 @@
   "rarity" : "Essential",
   "description" : "A device extracting power from a fragment of the Zero Mirror.",
   "shortdescription" : "Nil",
-  "category" : "arcana_orb",
+  "category" : "wand",
+  "tooltipFields" : {"subtitle" : "Orb"},
   "twoHanded" : false,
   "itemTags" : ["weapon","staff"],
   "tooltipKind" : "staff",
@@ -118,5 +119,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/artifact_weapons/artifact_shortbow_libertas/artifact_shortbow_libertas.activeitem
+++ b/items/active/weapons/artifact_weapons/artifact_shortbow_libertas/artifact_shortbow_libertas.activeitem
@@ -7,7 +7,8 @@
   "description" : "A bow infused with the unconfined wind.",
   "shortdescription" : "Libertas",
   "tooltipKind" : "base",
-  "category" : "arcana_shortbow",
+  "category" : "bow",
+  "tooltipFields" : {"subtitle" : "Shortbow"},
   "twoHanded" : true,
   "itemTags" : ["weapon","ranged"],
 
@@ -80,5 +81,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/artifact_weapons/artifact_staff_duality/artifact_staff_duality.activeitem
+++ b/items/active/weapons/artifact_weapons/artifact_staff_duality/artifact_staff_duality.activeitem
@@ -6,7 +6,8 @@
   "rarity" : "Essential",
   "description" : "Bringer of the radiant light and the colorless void.",
   "shortdescription" : "Duality",
-  "category" : "longstaff",
+  "category" : "staff",
+  "tooltipFields" : {"subtitle" : "Longstaff"},
   "twoHanded" : true,
   "itemTags" : ["weapon","staff"],
   "tooltipKind" : "staff",
@@ -159,5 +160,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/avostone_weapons/avostone_lance_1/avostone_lance_1.activeitem
+++ b/items/active/weapons/avostone_weapons/avostone_lance_1/avostone_lance_1.activeitem
@@ -7,7 +7,8 @@
   "description" : "A bright spear crafted from avostone.",
   "shortdescription" : "Star Breaker",
   "tooltipKind" : "sword",
-  "category" : "arcana_lance",
+  "category" : "spear",
+  "tooltipFields" : {"subtitle" : "Lance"},
   "twoHanded" : true,
   "itemTags" : ["weapon","melee","spear"],
   "collectablesOnPickup" : { "arcana_collection_weapon_arcane" : "avostone_lance_1" },
@@ -48,5 +49,5 @@
     "cooldownTime" : 0.4
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/conflagration_weapons/conflagration_greatsword_1/conflagration_greatsword_1.activeitem
+++ b/items/active/weapons/conflagration_weapons/conflagration_greatsword_1/conflagration_greatsword_1.activeitem
@@ -7,7 +7,8 @@
   "description" : "A burning greatsword.",
   "shortdescription" : "Fiery Greatsword",
   "tooltipKind" : "sword",
-  "category" : "arcana_greatsword",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Greatsword"},
   "twoHanded" : true,
   "itemTags" : ["weapon","melee"],
 
@@ -30,5 +31,5 @@
     "baseDps" : 8.0
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/conflagration_weapons/conflagration_shortbow_1/conflagration_shortbow_1.activeitem
+++ b/items/active/weapons/conflagration_weapons/conflagration_shortbow_1/conflagration_shortbow_1.activeitem
@@ -7,7 +7,8 @@
   "description" : "A molten shortbow.",
   "shortdescription" : "Firestorm",
   "tooltipKind" : "base",
-  "category" : "arcana_shortbow",
+  "category" : "bow",
+  "tooltipFields" : {"subtitle" : "Shortbow"},
   "twoHanded" : true,
   "itemTags" : ["weapon","ranged"],
 
@@ -76,5 +77,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/detritus_weapons/detritus_greatsword_1/detritus_greatsword_1.activeitem
+++ b/items/active/weapons/detritus_weapons/detritus_greatsword_1/detritus_greatsword_1.activeitem
@@ -7,9 +7,10 @@
   "description" : "A greatsword made with various salvaged parts.",
   "shortdescription" : "Detritus Greatsword",
   "tooltipKind" : "sword",
-  "category" : "arcana_greatsword",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Greatsword"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee"],
+  "itemTags" : ["weapon","melee","greatsword"],
 
   "inventoryIcon" : "icon.png",
 
@@ -30,5 +31,5 @@
     "baseDps" : 8.4
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/elysia_weapons/elysia_doubleBlade_1/elysia_doubleBlade_1.activeitem
+++ b/items/active/weapons/elysia_weapons/elysia_doubleBlade_1/elysia_doubleBlade_1.activeitem
@@ -7,7 +7,8 @@
   "description" : "A bladed weapon created from some sort of a durable glass material.",
   "shortdescription" : "Elysian Double Blade",
   "tooltipKind" : "sword",
-  "category" : "arcana_doubleBlade",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Double Blade"},
   "twoHanded" : true,
   "itemTags" : ["weapon","melee"],
 
@@ -30,5 +31,5 @@
     "baseDps" : 4.6
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/havencrest_weapons/havencrest_shortbow_1/havencrest_shortbow_1.activeitem
+++ b/items/active/weapons/havencrest_weapons/havencrest_shortbow_1/havencrest_shortbow_1.activeitem
@@ -7,7 +7,8 @@
   "description" : "A shortbow made from arcanium, can instantly fire arrows.",
   "shortdescription" : "Arcanium Shortbow",
   "tooltipKind" : "base",
-  "category" : "arcana_shortbow",
+  "category" : "bow",
+  "tooltipFields" : {"subtitle" : "Shortbow"},
   "twoHanded" : true,
   "itemTags" : ["weapon","ranged"],
   "collectablesOnPickup" : { "arcana_collection_weapon_arcane" : "havencrest_shortbow_1" },
@@ -77,5 +78,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/hephaestus_weapons/hephaestus_staff_1/hephaestus_staff_1.activeitem
+++ b/items/active/weapons/hephaestus_weapons/hephaestus_staff_1/hephaestus_staff_1.activeitem
@@ -6,7 +6,8 @@
   "rarity" : "Common",
   "description" : "Flame-infused staff of the ancient fire.",
   "shortdescription" : "Hestia",
-  "category" : "longstaff",
+  "category" : "staff",
+  "tooltipFields" : {"subtitle" : "Longstaff"},
   "twoHanded" : true,
   "itemTags" : ["weapon","staff"],
   "tooltipKind" : "staff",
@@ -160,5 +161,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/horizon_weapons/horizon_lance_1/horizon_lance_1.activeitem
+++ b/items/active/weapons/horizon_weapons/horizon_lance_1/horizon_lance_1.activeitem
@@ -7,7 +7,8 @@
   "description" : "A devastating lance.",
   "shortdescription" : "Destruction",
   "tooltipKind" : "sword",
-  "category" : "arcana_lance",
+  "category" : "spear",
+  "tooltipFields" : {"subtitle" : "Lance"},
   "twoHanded" : true,
   "itemTags" : ["weapon","melee","spear"],
   "collectablesOnPickup" : { "arcana_collection_weapon_arcane" : "horizon_lance_1" },
@@ -48,5 +49,5 @@
     "cooldownTime" : 0.4
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/luye_weapons/luye_glaive_1/luye_glaive_1.activeitem
+++ b/items/active/weapons/luye_weapons/luye_glaive_1/luye_glaive_1.activeitem
@@ -7,7 +7,8 @@
   "description" : "A glaive crafted from aegistalt and corrodium.",
   "shortdescription" : "Corrodium Glaive",
   "tooltipKind" : "sword",
-  "category" : "arcana_glaive",
+  "category" : "spear",
+  "tooltipFields" : {"subtitle" : "Glaive"},
   "twoHanded" : true,
   "itemTags" : ["weapon","melee"],
 
@@ -45,5 +46,5 @@
   },
   
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/luye_weapons/luye_moonBlade_1/luye_moonBlade_1.activeitem
+++ b/items/active/weapons/luye_weapons/luye_moonBlade_1/luye_moonBlade_1.activeitem
@@ -7,7 +7,8 @@
   "description" : "A moon-blade crafted from aegistalt and corrodium.",
   "shortdescription" : "Corrodium Moon Blade",
   "tooltipKind" : "sword",
-  "category" : "arcana_moonBlade",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Moon Blade"},
   "twoHanded" : true,
   "itemTags" : ["weapon","melee"],
 
@@ -39,5 +40,5 @@
     "baseDps" : 12.2
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/misc_weapons/misc_katana_ironKatana/misc_katana_ironKatana.activeitem
+++ b/items/active/weapons/misc_weapons/misc_katana_ironKatana/misc_katana_ironKatana.activeitem
@@ -7,9 +7,10 @@
   "description" : "A sharp iron katana.",
   "shortdescription" : "Iron Katana",
   "tooltipKind" : "sword",
-  "category" : "arcana_katana",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Katana"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee"],
+  "itemTags" : ["weapon","melee","katana"],
 
   "inventoryIcon" : "icon.png",
 

--- a/items/active/weapons/misc_weapons/misc_katana_neon/misc_katana_neon.activeitem
+++ b/items/active/weapons/misc_weapons/misc_katana_neon/misc_katana_neon.activeitem
@@ -7,9 +7,10 @@
   "description" : "A blade that cuts even the night sky.",
   "shortdescription" : "Neon",
   "tooltipKind" : "sword",
-  "category" : "arcana_katana",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Katana"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee"],
+  "itemTags" : ["weapon","melee","katana"],
 
   "inventoryIcon" : "icon.png",
 
@@ -39,5 +40,5 @@
 
   "altAbilityType" : "parry",
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/misc_weapons/misc_katana_ouroburos/misc_katana_ouroburos.activeitem
+++ b/items/active/weapons/misc_weapons/misc_katana_ouroburos/misc_katana_ouroburos.activeitem
@@ -7,9 +7,10 @@
   "description" : "Blade of the endless serpent.",
   "shortdescription" : "Ouroburos",
   "tooltipKind" : "sword",
-  "category" : "arcana_katana",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Katana"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee"],
+  "itemTags" : ["weapon","melee","katana"],
 
   "inventoryIcon" : "icon.png",
 
@@ -30,5 +31,5 @@
     "baseDps" : 10.1
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/misc_weapons/misc_katana_viridescentKatana/misc_katana_viridescentKatana.activeitem
+++ b/items/active/weapons/misc_weapons/misc_katana_viridescentKatana/misc_katana_viridescentKatana.activeitem
@@ -7,9 +7,10 @@
   "description" : "Also known as the green sword!",
   "shortdescription" : "Viridescent Katana",
   "tooltipKind" : "sword",
-  "category" : "arcana_katana",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Katana"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee"],
+  "itemTags" : ["weapon","melee","katana"],
 
   "inventoryIcon" : "icon.png",
 
@@ -39,5 +40,5 @@
 
   "altAbilityType" : "parry",
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/misc_weapons/misc_wand_tripleDecker/misc_wand_tripleDecker.activeitem
+++ b/items/active/weapons/misc_weapons/misc_wand_tripleDecker/misc_wand_tripleDecker.activeitem
@@ -6,7 +6,7 @@
   "rarity" : "Uncommon",
   "description" : "Taste the icy sweetness!",
   "shortdescription" : "Trip1e Decker",
-  "category" : "unique",
+  "category" : "uniqueWeapon",
   "twoHanded" : false,
   "itemTags" : ["weapon","staff"],
   "tooltipKind" : "staff",

--- a/items/active/weapons/monarch_weapons/monarch_doubleBlade_1/monarch_doubleBlade_1.activeitem
+++ b/items/active/weapons/monarch_weapons/monarch_doubleBlade_1/monarch_doubleBlade_1.activeitem
@@ -7,9 +7,10 @@
   "description" : "A pale double bladed weapon.",
   "shortdescription" : "Holosium Double Blade",
   "tooltipKind" : "sword",
-  "category" : "arcana_doubleBlade",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Double Blade"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee"],
+  "itemTags" : ["weapon","melee","doubleblade"],
   "collectablesOnPickup" : { "arcana_collection_weapon_arcane" : "monarch_doubleBlade_1" },
 
   "inventoryIcon" : "icon.png",
@@ -31,5 +32,5 @@
     "baseDps" : 9.0
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/monarch_weapons/monarch_lance_1/monarch_lance_1.activeitem
+++ b/items/active/weapons/monarch_weapons/monarch_lance_1/monarch_lance_1.activeitem
@@ -7,7 +7,8 @@
   "description" : "A pale lance.",
   "shortdescription" : "Iustitia",
   "tooltipKind" : "sword",
-  "category" : "arcana_lance",
+  "category" : "spear",
+  "tooltipFields" : {"subtitle" : "Lance"},
   "twoHanded" : true,
   "itemTags" : ["weapon","melee","spear"],
   "collectablesOnPickup" : { "arcana_collection_weapon_arcane" : "monarch_lance_1" },
@@ -48,5 +49,5 @@
     "cooldownTime" : 0.3
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/monarch_weapons/monarch_staff_1/monarch_staff_1.activeitem
+++ b/items/active/weapons/monarch_weapons/monarch_staff_1/monarch_staff_1.activeitem
@@ -6,7 +6,8 @@
   "rarity" : "Rare",
   "description" : "A pale staff.",
   "shortdescription" : "Elucidation",
-  "category" : "longstaff",
+  "category" : "staff",
+  "tooltipFields" : {"subtitle" : "Longstaff"},
   "twoHanded" : true,
   "itemTags" : ["weapon","staff"],
   "tooltipKind" : "staff",
@@ -160,5 +161,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/orion_weapons/orion_greatsword_1/orion_greatsword_1.activeitem
+++ b/items/active/weapons/orion_weapons/orion_greatsword_1/orion_greatsword_1.activeitem
@@ -7,9 +7,10 @@
   "description" : "A high tech greatsword.",
   "shortdescription" : "Orion Greatsword",
   "tooltipKind" : "sword",
-  "category" : "arcana_greatsword",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Greatsword"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee"],
+  "itemTags" : ["weapon","melee","greatsword"],
   "collectablesOnPickup" : { "arcana_collection_weapon_stellar" : "orion_greatsword_1" },
 
   "inventoryIcon" : "icon.png",
@@ -37,5 +38,5 @@
     "baseDps" : 9.4
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/prototype_weapons/prototype_doubleBlade_1/prototype_doubleBlade_1.activeitem
+++ b/items/active/weapons/prototype_weapons/prototype_doubleBlade_1/prototype_doubleBlade_1.activeitem
@@ -8,6 +8,7 @@
   "shortdescription" : "Prototype Double Blade",
   "tooltipKind" : "sword",
   "category" : "arcana_doubleBlade",
+  "tooltipFields" : {"subtitle" : "Double Blade"},
   "twoHanded" : true,
   "itemTags" : ["weapon","melee"],
 
@@ -30,5 +31,5 @@
     "baseDps" : 5.0
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/prototype_weapons/prototype_doubleBlade_1/prototype_doubleBlade_1.activeitem
+++ b/items/active/weapons/prototype_weapons/prototype_doubleBlade_1/prototype_doubleBlade_1.activeitem
@@ -7,7 +7,7 @@
   "description" : "A prototype of a weapon.",
   "shortdescription" : "Prototype Double Blade",
   "tooltipKind" : "sword",
-  "category" : "arcana_doubleBlade",
+  "category" : "broadsword",
   "tooltipFields" : {"subtitle" : "Double Blade"},
   "twoHanded" : true,
   "itemTags" : ["weapon","melee"],

--- a/items/active/weapons/prototype_weapons/prototype_greatsword_1/prototype_greatsword_1.activeitem
+++ b/items/active/weapons/prototype_weapons/prototype_greatsword_1/prototype_greatsword_1.activeitem
@@ -7,9 +7,10 @@
   "description" : "A prototype of a weapon.",
   "shortdescription" : "Prototype Greatsword",
   "tooltipKind" : "sword",
-  "category" : "arcana_greatsword",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Greatsword"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee"],
+  "itemTags" : ["weapon","melee","greatsword"],
 
   "inventoryIcon" : "icon.png",
 
@@ -30,5 +31,5 @@
     "baseDps" : 5.0
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/solar_weapons/solar_lance_1/solar_lance_1.activeitem
+++ b/items/active/weapons/solar_weapons/solar_lance_1/solar_lance_1.activeitem
@@ -7,7 +7,8 @@
   "description" : "A burning lance made from solar crystals.",
   "shortdescription" : "Molten Skewer",
   "tooltipKind" : "sword",
-  "category" : "arcana_lance",
+  "category" : "spear",
+  "tooltipFields" : {"subtitle" : "Lance"},
   "twoHanded" : true,
   "itemTags" : ["weapon","melee","spear"],
 
@@ -47,5 +48,5 @@
     "cooldownTime" : 0.4
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/splendor_weapons/splendor_katana_1/splendor_katana_1.activeitem
+++ b/items/active/weapons/splendor_weapons/splendor_katana_1/splendor_katana_1.activeitem
@@ -7,9 +7,10 @@
   "description" : "A visually bright and colorful katana.",
   "shortdescription" : "Splendid Katana",
   "tooltipKind" : "sword",
-  "category" : "arcana_katana",
+  "category" : "broadsword",
+  "tooltipFields" : {"subtitle" : "Katana"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee"],
+  "itemTags" : ["weapon","melee","katana"],
 
   "inventoryIcon" : "icon.png",
 
@@ -30,5 +31,5 @@
     "baseDps" : 8.6
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/splendor_weapons/splendor_shortbow_1/splendor_shortbow_1.activeitem
+++ b/items/active/weapons/splendor_weapons/splendor_shortbow_1/splendor_shortbow_1.activeitem
@@ -7,9 +7,10 @@
   "description" : "A shortbow, shining magnificently.",
   "shortdescription" : "Splendid Shortbow",
   "tooltipKind" : "base",
-  "category" : "arcana_shortbow",
+  "category" : "bow",
+  "tooltipFields" : {"subtitle" : "Shortbow"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","ranged"],
+  "itemTags" : ["weapon","ranged","bow","shortbow"],
 
   "inventoryIcon" : "icon.png",
 
@@ -78,5 +79,5 @@
     }
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/thalassa_weapons/thalassa_beamCannon_1/thalassa_beamCannon_1.activeitem
+++ b/items/active/weapons/thalassa_weapons/thalassa_beamCannon_1/thalassa_beamCannon_1.activeitem
@@ -7,7 +7,8 @@
   "rarity" : "Uncommon",
   "description" : "The eye of the crystallized sea.",
   "shortdescription" : "Aquamarine Eye",
-  "category" : "arcana_beamCannon",
+  "category" : "uniqueWeapon",
+  "tooltipFields" : {"subtitle" : "Beam Cannon"},
   "itemTags" : ["weapon","ranged","upgradeableWeapon"],
   "twoHanded" : true,
   "collectablesOnPickup" : { "arcana_collection_weapon_elemental" : "thalassa_beamCannon_1" },
@@ -43,5 +44,5 @@
 	"beamLength" : 24
   },
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/active/weapons/workshop_weapons/workshop_battleaxe_1/workshop_battleaxe_1.activeitem
+++ b/items/active/weapons/workshop_weapons/workshop_battleaxe_1/workshop_battleaxe_1.activeitem
@@ -7,9 +7,10 @@
   "description" : "A battleaxe used by Section 8 of the Workshop of Gears.",
   "shortdescription" : "Gears S8 Battleaxe",
   "tooltipKind" : "sword",
-  "category" : "arcana_battleaxe",
+  "category" : "axe",
+  "tooltipFields" : {"subtitle" : "Battleaxe"},
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee","broadsword"],
+  "itemTags" : ["weapon","melee","battleaxe","axe"],
 
   "inventoryIcon" : "workshop_battleaxe_1.png",
 
@@ -38,5 +39,5 @@
 
   "altAbilityType" : "risingslash",
 
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+  "builder" : "/items/buildscripts/arcana_buildunrandweapon.lua"
 }

--- a/items/buildscripts/arcana_buildunrandweapon.lua
+++ b/items/buildscripts/arcana_buildunrandweapon.lua
@@ -1,0 +1,88 @@
+--Basically a mix of vanilla and Betabound's weapon builder.
+--Allows for custom tooltip fields and includes some optimizations.
+require "/scripts/util.lua"
+require "/scripts/vec2.lua"
+require "/scripts/versioningutils.lua"
+require "/items/buildscripts/abilities.lua"
+
+function build(directory, config, parameters, level, seed)
+  local configParameter = function(keyName, defaultValue)
+    if parameters[keyName] ~= nil then
+      return parameters[keyName]
+    elseif config[keyName] ~= nil then
+      return config[keyName]
+    else
+      return defaultValue
+    end
+  end
+
+  if level and not configParameter("fixedLevel", true) then
+    parameters.level = level
+  end
+
+  setupAbility(config, parameters, "primary")
+  setupAbility(config, parameters, "alt")
+
+  -- elemental type and config (for alt ability)
+  local elementalType = configParameter("elementalType", "physical")
+  replacePatternInData(config, nil, "<elementalType>", elementalType)
+  if config.altAbility and config.altAbility.elementalConfig then
+    util.mergeTable(config.altAbility, config.altAbility.elementalConfig[elementalType])
+  end
+
+  -- calculate damage level multiplier
+  config.damageLevelMultiplier = root.evalFunction("weaponDamageLevelMultiplier", configParameter("level", 1))
+
+  -- palette swaps
+  config.paletteSwaps = "?replace"
+  if config.palette then
+    local palette = root.assetJson(util.absolutePath(directory, config.palette))
+    local selectedSwaps = palette.swaps[configParameter("colorIndex", 1)]
+    for k, v in pairs(selectedSwaps) do
+      config.paletteSwaps = string.format("%s;%s=%s", config.paletteSwaps, k, v)
+    end
+  end
+  if type(config.inventoryIcon) == "string" then
+    config.inventoryIcon = config.inventoryIcon .. config.paletteSwaps
+  else
+    for i, drawable in ipairs(config.inventoryIcon) do
+      if drawable.image then drawable.image = drawable.image .. config.paletteSwaps end
+    end
+  end
+
+  -- gun offsets
+  if config.baseOffset then
+    construct(config, "animationCustom", "animatedParts", "parts", "middle", "properties")
+    config.animationCustom.animatedParts.parts.middle.properties.offset = config.baseOffset
+    if config.muzzleOffset then
+      config.muzzleOffset = vec2.add(config.muzzleOffset, config.baseOffset)
+    end
+  end
+
+  -- populate tooltip fields
+  if config.tooltipKind ~= "base" then
+    config.tooltipFields = config.tooltipFields or {}
+    config.tooltipFields.levelLabel = util.round(configParameter("level", 1), 1)
+    config.tooltipFields.dpsLabel = util.round((config.primaryAbility.baseDps or 0) * config.damageLevelMultiplier, 1)
+    config.tooltipFields.speedLabel = util.round(1 / (config.primaryAbility.fireTime or 1.0), 1)
+    config.tooltipFields.damagePerShotLabel = util.round((config.primaryAbility.baseDps or 0) * (config.primaryAbility.fireTime or 1.0) * config.damageLevelMultiplier, 1)
+    config.tooltipFields.energyPerShotLabel = util.round((config.primaryAbility.energyUsage or 0) * (config.primaryAbility.fireTime or 1.0), 1)
+    if elementalType ~= "physical" then
+      config.tooltipFields.damageKindImage = "/interface/elements/"..elementalType..".png"
+    end
+    if config.primaryAbility then
+      config.tooltipFields.primaryAbilityTitleLabel = "Primary:"
+      config.tooltipFields.primaryAbilityLabel = config.primaryAbility.name or "unknown"
+    end
+    if config.altAbility then
+      config.tooltipFields.altAbilityTitleLabel = "Special:"
+      config.tooltipFields.altAbilityLabel = config.altAbility.name or "unknown"
+    end
+  end
+
+  -- set price
+  -- TODO: should this be handled elsewhere?
+  config.price = (config.price or 0) * root.evalFunction("itemLevelPriceMultiplier", configParameter("level", 1))
+
+  return config, parameters
+end

--- a/items/buildscripts/arcana_buildweapon.lua
+++ b/items/buildscripts/arcana_buildweapon.lua
@@ -1,0 +1,210 @@
+--Basically a mix of vanilla and Betabound's weapon builder.
+--Allows for custom tooltip fields and includes some optimizations.
+require "/scripts/util.lua"
+require "/scripts/vec2.lua"
+require "/scripts/versioningutils.lua"
+require "/scripts/staticrandom.lua"
+require "/items/buildscripts/abilities.lua"
+
+function build(directory, config, parameters, level, seed)
+  local configParameter = function(keyName, defaultValue)
+    if parameters[keyName] ~= nil then
+      return parameters[keyName]
+    elseif config[keyName] ~= nil then
+      return config[keyName]
+    else
+      return defaultValue
+    end
+  end
+
+  if level and not configParameter("fixedLevel", false) then
+    parameters.level = level
+  end
+
+  -- initialize randomization
+  if seed then
+    parameters.seed = seed
+  else
+    seed = configParameter("seed")
+    if not seed then
+      math.randomseed(util.seedTime())
+      seed = math.random(1, 4294967295)
+      parameters.seed = seed
+    end
+  end
+
+  -- select the generation profile to use
+  local builderConfig = {}
+  if config.builderConfig then
+    builderConfig = randomFromList(config.builderConfig, seed, "builderConfig")
+  end
+
+  -- select, load and merge abilities
+  setupAbility(config, parameters, "alt", builderConfig, seed)
+  setupAbility(config, parameters, "primary", builderConfig, seed)
+
+  -- elemental type
+  if not parameters.elementalType and builderConfig.elementalType then
+    parameters.elementalType = randomFromList(builderConfig.elementalType, seed, "elementalType")
+  end
+  local elementalType = configParameter("elementalType", "physical")
+
+  -- elemental config
+  if builderConfig.elementalConfig then
+    util.mergeTable(config, builderConfig.elementalConfig[elementalType])
+  end
+  if config.altAbility and config.altAbility.elementalConfig then
+    util.mergeTable(config.altAbility, config.altAbility.elementalConfig[elementalType])
+  end
+
+  -- elemental tag
+  replacePatternInData(config, nil, "<elementalType>", elementalType)
+  replacePatternInData(config, nil, "<elementalName>", elementalType:gsub("^%l", string.upper))
+
+  -- name
+  if not parameters.shortdescription and builderConfig.nameGenerator then
+    parameters.shortdescription = root.generateName(util.absolutePath(directory, builderConfig.nameGenerator), seed)
+  end
+
+  -- merge damage properties
+  if builderConfig.damageConfig then
+    util.mergeTable(config.damageConfig or {}, builderConfig.damageConfig)
+  end
+
+  -- preprocess shared primary attack config
+  parameters.primaryAbility = parameters.primaryAbility or {}
+  parameters.primaryAbility.fireTimeFactor = valueOrRandom(parameters.primaryAbility.fireTimeFactor, seed, "fireTimeFactor")
+  parameters.primaryAbility.baseDpsFactor = valueOrRandom(parameters.primaryAbility.baseDpsFactor, seed, "baseDpsFactor")
+  parameters.primaryAbility.energyUsageFactor = valueOrRandom(parameters.primaryAbility.energyUsageFactor, seed, "energyUsageFactor")
+
+  config.primaryAbility.fireTime = scaleConfig(parameters.primaryAbility.fireTimeFactor, config.primaryAbility.fireTime)
+  config.primaryAbility.baseDps = scaleConfig(parameters.primaryAbility.baseDpsFactor, config.primaryAbility.baseDps)
+  config.primaryAbility.energyUsage = scaleConfig(parameters.primaryAbility.energyUsageFactor, config.primaryAbility.energyUsage) or 0
+
+  -- preprocess melee primary attack config
+  if config.primaryAbility.damageConfig and config.primaryAbility.damageConfig.knockbackRange then
+    config.primaryAbility.damageConfig.knockback = scaleConfig(parameters.primaryAbility.fireTimeFactor, config.primaryAbility.damageConfig.knockbackRange)
+  end
+
+  -- preprocess ranged primary attack config
+  if config.primaryAbility.projectileParameters then
+    config.primaryAbility.projectileType = randomFromList(config.primaryAbility.projectileType, seed, "projectileType")
+    config.primaryAbility.projectileCount = randomIntInRange(config.primaryAbility.projectileCount, seed, "projectileCount") or 1
+    config.primaryAbility.fireType = randomFromList(config.primaryAbility.fireType, seed, "fireType") or "auto"
+    config.primaryAbility.burstCount = randomIntInRange(config.primaryAbility.burstCount, seed, "burstCount")
+    config.primaryAbility.burstTime = randomInRange(config.primaryAbility.burstTime, seed, "burstTime")
+    if config.primaryAbility.projectileParameters.knockbackRange then
+      config.primaryAbility.projectileParameters.knockback = scaleConfig(parameters.primaryAbility.fireTimeFactor, config.primaryAbility.projectileParameters.knockbackRange)
+    end
+  end
+
+  -- calculate damage level multiplier
+  config.damageLevelMultiplier = root.evalFunction("weaponDamageLevelMultiplier", configParameter("level", 1))
+
+  -- build palette swap directives
+  config.paletteSwaps = "?replace"
+  if builderConfig.palette then
+    local palette = root.assetJson(util.absolutePath(directory, builderConfig.palette))
+    local selectedSwaps = randomFromList(palette.swaps, seed, "paletteSwaps")
+    for k, v in pairs(selectedSwaps) do
+      config.paletteSwaps = string.format("%s;%s=%s", config.paletteSwaps, k, v)
+    end
+  end
+
+  -- merge extra animationCustom
+  if builderConfig.animationCustom then
+    util.mergeTable(config.animationCustom or {}, builderConfig.animationCustom)
+  end
+
+  -- animation parts
+  if builderConfig.animationParts then
+    config.animationParts = config.animationParts or {}
+    if parameters.animationPartVariants == nil then parameters.animationPartVariants = {} end
+    for k, v in pairs(builderConfig.animationParts) do
+      if type(v) == "table" then
+        if v.variants and (not parameters.animationPartVariants[k] or parameters.animationPartVariants[k] > v.variants) then
+          parameters.animationPartVariants[k] = randomIntInRange({1, v.variants}, seed, "animationPart"..k)
+        end
+        config.animationParts[k] = util.absolutePath(directory, string.gsub(v.path, "<variant>", parameters.animationPartVariants[k] or ""))
+        if v.paletteSwap then
+          config.animationParts[k] = config.animationParts[k] .. config.paletteSwaps
+        end
+      else
+        config.animationParts[k] = v
+      end
+    end
+  end
+
+  -- set gun part offsets
+  local partImagePositions = {}
+  if builderConfig.gunParts then
+    construct(config, "animationCustom", "animatedParts", "parts")
+    local imageOffset = {0,0}
+    local gunPartOffset = {0,0}
+    for _,part in ipairs(builderConfig.gunParts) do
+      local imageSize = root.imageSize(config.animationParts[part])
+      construct(config.animationCustom.animatedParts.parts, part, "properties")
+
+      imageOffset = vec2.add(imageOffset, {imageSize[1] / 2, 0})
+      config.animationCustom.animatedParts.parts[part].properties.offset = {config.baseOffset[1] + imageOffset[1] / 8, config.baseOffset[2]}
+      partImagePositions[part] = copy(imageOffset)
+      imageOffset = vec2.add(imageOffset, {imageSize[1] / 2, 0})
+    end
+    config.muzzleOffset = vec2.add(config.baseOffset, vec2.add(config.muzzleOffset or {0,0}, vec2.div(imageOffset, 8)))
+  end
+
+  -- elemental fire sounds
+  if config.fireSounds then
+    construct(config, "animationCustom", "sounds", "fire")
+    local sound = randomFromList(config.fireSounds, seed, "fireSound")
+    config.animationCustom.sounds.fire = type(sound) == "table" and sound or { sound }
+  end
+
+  -- build inventory icon
+  if not config.inventoryIcon and config.animationParts then
+    config.inventoryIcon = jarray()
+    local parts = builderConfig.iconDrawables or {}
+    for _,partName in pairs(parts) do
+      local drawable = {
+        image = config.animationParts[partName] .. config.paletteSwaps,
+        position = partImagePositions[partName]
+      }
+      table.insert(config.inventoryIcon, drawable)
+    end
+  end
+
+  -- populate tooltip fields
+  config.tooltipFields = config.tooltipFields or {}
+  local fireTime = parameters.primaryAbility.fireTime or config.primaryAbility.fireTime or 1.0
+  local baseDps = parameters.primaryAbility.baseDps or config.primaryAbility.baseDps or 0
+  local energyUsage = parameters.primaryAbility.energyUsage or config.primaryAbility.energyUsage or 0
+  config.tooltipFields.levelLabel = util.round(configParameter("level", 1), 1)
+  config.tooltipFields.dpsLabel = util.round(baseDps * config.damageLevelMultiplier, 1)
+  config.tooltipFields.speedLabel = util.round(1 / fireTime, 1)
+  config.tooltipFields.damagePerShotLabel = util.round(baseDps * fireTime * config.damageLevelMultiplier, 1)
+  config.tooltipFields.energyPerShotLabel = util.round(energyUsage * fireTime, 1)
+  if elementalType ~= "physical" then
+    config.tooltipFields.damageKindImage = "/interface/elements/"..elementalType..".png"
+  end
+  if config.primaryAbility then
+    config.tooltipFields.primaryAbilityTitleLabel = "Primary:"
+    config.tooltipFields.primaryAbilityLabel = config.primaryAbility.name or "unknown"
+  end
+  if config.altAbility then
+    config.tooltipFields.altAbilityTitleLabel = "Special:"
+    config.tooltipFields.altAbilityLabel = config.altAbility.name or "unknown"
+  end
+
+  -- set price
+  config.price = (config.price or 0) * root.evalFunction("itemLevelPriceMultiplier", configParameter("level", 1))
+
+  return config, parameters
+end
+
+function scaleConfig(ratio, value)
+  if type(value) == "table" then
+    return util.lerp(ratio, value[1], value[2])
+  else
+    return value
+  end
+end

--- a/objects/arcana_vendor/arcana_vendor_2/arcana_vendor_2.object
+++ b/objects/arcana_vendor/arcana_vendor_2/arcana_vendor_2.object
@@ -14,7 +14,7 @@
     "paneLayoutOverride" : {
       "windowtitle" : {
         "title" : " Bookstore",
-        "subtitle" : " New books will arrive from time to time!"
+        "subtitle" : " New books will arrive with time!"
       }
     },
     "buyFactor" : 4.0,
@@ -39,7 +39,7 @@
 	  { "item" : "arcana_codex_steelblades_2-codex" },
 	  { "item" : "arcana_codex_monarch_1-codex" },
 	  { "item" : "arcana_codex_monarch_2-codex" },
-      { "item" : "arcana_codex_havencrest_1-codex" },
+	  { "item" : "arcana_codex_havencrest_1-codex" },
 	  { "item" : "arcana_codex_havencrest_2-codex" },
 	  { "item" : "arcana_codex_havencrest_3-codex" }
     ]

--- a/objects/arcana_vendor/arcana_vendor_7/arcana_vendor_7.object
+++ b/objects/arcana_vendor/arcana_vendor_7/arcana_vendor_7.object
@@ -12,16 +12,19 @@
   "interactData" : {
     "config" : "/interface/windowconfig/vendingmachine.config",
     "paneLayoutOverride" : {
+    "close" : {
+      "position" : [161, 246]
+      },
       "windowtitle" : {
-        "title" : " ???",
-        "subtitle" : " 'Unobtainable' isn't in my dictionary."
+        "title" : "???",
+        "subtitle" : "'Unobtainable' isn't in my dictionary"
       }
     },
     "buyFactor" : 100.0,
     "sellFactor" : 0.2,
     "items" : [
 	  { "item" : "arcana_sigils_abyssSigil" },
-      { "item" : "arcana_sigils_avoSigil" },
+	  { "item" : "arcana_sigils_avoSigil" },
 	  { "item" : "arcana_sigils_azureSigil" },
 	  { "item" : "arcana_sigils_electricSigil" },
 	  { "item" : "arcana_sigils_fireSigil" },
@@ -50,7 +53,7 @@
   
   "scripts" : [ "/objects/arcana_lua_object_chat.lua" ],
   "scriptDelta" : 20,
-
+  "mouthPosition" : [1.5,-0.25],
   "chatRadius" : 10,
   "chatCooldown" : 15,
   "chatOptions" : [

--- a/objects/arcana_vendor/arcana_vendor_8/arcana_vendor_8.object
+++ b/objects/arcana_vendor/arcana_vendor_8/arcana_vendor_8.object
@@ -53,7 +53,7 @@
   
   "scripts" : [ "/objects/arcana_lua_object_chat.lua" ],
   "scriptDelta" : 20,
-
+  "mouthPosition" : [-2.5, -2],
   "chatRadius" : 10,
   "chatCooldown" : 15,
   "chatOptions" : [


### PR DESCRIPTION
• Made the Station/Shady Vendor speak from his mouth instead of his computer/small crate
• Moved interface elements in the Shady Vendor to prevent overlap
• Shortened the bookstore's subtitle so it fits in the menu
• Added scripts to allow inventory mods to recognize Arcana custom weapon categories as weapons