### PR TITLE
Fix for invisible windflowers. The file referenced does not exist. 

### DIFF
--- a/objects/farmables/arcana_farmable_windflowerSeed/arcana_farmable_windflowerSeed.object
+++ b/objects/farmables/arcana_farmable_windflowerSeed/arcana_farmable_windflowerSeed.object
@@ -12,7 +12,7 @@
   "inventoryIcon" : "icon.png",
 
   "tooltipKind" : "seed",
-  "largeImage" : "arcana_farmable_windflowerSeed.png:default.3.0",
+  "largeImage" : "body.png:default.3.0",
 
 
   "orientations" : [

--- a/objects/farmables/arcana_farmable_windflowerSeed/arcana_farmable_windflowerSeed_wild.object
+++ b/objects/farmables/arcana_farmable_windflowerSeed/arcana_farmable_windflowerSeed_wild.object
@@ -15,7 +15,7 @@
   "inventoryIcon" : "icon.png",
   "orientations" : [
     {
-      "dualImage" : "arcana_farmable_windflowerSeed.png:<color>.<stage>.<alt>",
+      "dualImage" : "body.png:<color>.<stage>.<alt>",
       "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,


### PR DESCRIPTION
This change should fix this error causing windflowers to not show:
```
[Error] Could not load image asset '/objects/farmables/arcana_farmable_windflowerSeed/arcana_farmable_windflowerSeed.png:default.3.3', using placeholder default.
(AssetException) No associated frames file found for image '/objects/farmables/arcana_farmable_windflowerSeed/arcana_farmable_windflowerSeed.png' while resolving image frame '/objects/farmables/arcana_farmable_windflowerSeed/arcana_farmable_windflowerSeed.png:default.3.3'
[Error] Could not load image asset '/objects/farmables/arcana_farmable_windflowerSeed/arcana_farmable_windflowerSeed.png:default.2.2', using placeholder default.
(AssetException) No associated frames file found for image '/objects/farmables/arcana_farmable_windflowerSeed/arcana_farmable_windflowerSeed.png' while resolving image frame '/objects/farmables/arcana_farmable_windflowerSeed/arcana_farmable_windflowerSeed.png:default.2.2'
```
Before the change
![before](https://user-images.githubusercontent.com/59216157/218292060-497eaed3-b5d9-480b-939c-1025c75d54d7.png)
After the change
![After](https://user-images.githubusercontent.com/59216157/218292061-9b449530-e249-4143-91f0-28ccb5effa23.png)