### PR TITLE
Changelog popup

### DIFF
--- a/interface/scripted/arcana_updates/arcana_updates_gui.config
+++ b/interface/scripted/arcana_updates/arcana_updates_gui.config
@@ -1,4 +1,5 @@
 {
+  "version": 1, //Increment this to prompt an automatic popup when the player first logs in with the update! Setting it to 1 will NOT prompt it
   "gui" : {
     "panefeature" : {
       "type" : "panefeature"

--- a/player.config.patch
+++ b/player.config.patch
@@ -48,5 +48,11 @@
 		"value" : {
 			"baseValue" : 1.0
 		}
+	},
+	
+	{ 
+		"op" : "add",
+		"path" : "/deploymentConfig/scripts/-",
+		"value" : "/scripts/arcana_updatePopup.lua"
 	}
 ]

--- a/scripts/arcana_updatePopup.lua
+++ b/scripts/arcana_updatePopup.lua
@@ -1,0 +1,19 @@
+--By Silver Sokolova
+local ini = init or function() end
+function init() ini()
+  local interface = root.assetJson("/interface/scripted/arcana_updates/arcana_updates_gui.config")
+  local currentVersion = interface.version
+  if player.introComplete() then
+    local yv = player.getProperty("arcana_version")
+    if yv == nil then
+      player.setProperty("arcana_version", currentVersion)
+      yv = currentVersion
+    end
+    if yv < currentVersion then
+      sb.logInfo(string.format("[Arcana] Updating this character from %s to %s!", yv, currentVersion))
+      player.interact("scriptPane", interface)
+      player.setProperty("arcana_version", currentVersion)
+    end
+  end
+  interface = nil
+end


### PR DESCRIPTION
Increment the `version` value in "/interface/scripted/arcana_updates/arcana_updates_gui.config" to show a changelog upon logging into a character.
The changelog only shows once per character until the `version` is increased again, and will NOT show for new characters!